### PR TITLE
fix: fix duplicate imports warnings and add CI check

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -69,6 +69,17 @@ jobs:
       - name: Run dependency check
         run: pnpm depcheck
 
+      - name: Check for duplicate imports
+        run: |
+          # generateでduplicate imports警告が出ないことを確認
+          if pnpm generate 2>&1 | grep -q "Duplicated imports"; then
+            echo "❌ Duplicate imports detected!"
+            pnpm generate 2>&1 | grep "Duplicated imports"
+            exit 1
+          else
+            echo "✅ No duplicate imports found"
+          fi
+
       - name: Build
         run: pnpm build
 

--- a/tests/utils/password.test.ts
+++ b/tests/utils/password.test.ts
@@ -6,11 +6,11 @@ import {
   calculatePasswordEntropy,
   getPasswordCharset,
   estimateCrackTime,
-  generateUUID,
-  generateRandomHex,
   validateCreditCard,
   type PasswordOptions,
 } from '~/utils/password'
+import { generateUUID } from '~/utils/uuid'
+import { generateRandomHex } from '~/utils/random-number'
 
 describe('Password utilities', () => {
   describe('generatePassword', () => {
@@ -273,7 +273,7 @@ describe('Password utilities', () => {
     it('should generate hex string of correct length', () => {
       const hex = generateRandomHex(16)
       expect(hex).toHaveLength(16)
-      expect(hex).toMatch(/^[0-9a-f]+$/)
+      expect(hex).toMatch(/^[0-9a-fA-F]+$/)
     })
 
     it('should generate different hex strings', () => {
@@ -290,7 +290,7 @@ describe('Password utilities', () => {
     it('should handle single character', () => {
       const hex = generateRandomHex(1)
       expect(hex).toHaveLength(1)
-      expect(hex).toMatch(/^[0-9a-f]$/)
+      expect(hex).toMatch(/^[0-9a-fA-F]$/)
     })
   })
 

--- a/utils/calorie-calculator.ts
+++ b/utils/calorie-calculator.ts
@@ -1,14 +1,14 @@
 import type { Gender, ActivityLevel } from './health'
 
 export type Goal = 'maintain' | 'lose' | 'gain'
-export type WeightUnit = 'kg' | 'lbs'
+export type CalorieWeightUnit = 'kg' | 'lbs'
 export type HeightUnit = 'cm' | 'ft'
 
 export interface CalorieCalculatorInput {
   gender: Gender
   age: number
   weight: number
-  weightUnit: WeightUnit
+  weightUnit: CalorieWeightUnit
   height: number
   heightUnit: HeightUnit
   activityLevel: ActivityLevel
@@ -41,7 +41,7 @@ const goalAdjustments: Record<Goal, number> = {
 }
 
 // Convert units to metric
-function convertToMetric(value: number, unit: WeightUnit | HeightUnit): number {
+function convertToMetric(value: number, unit: CalorieWeightUnit | HeightUnit): number {
   switch (unit) {
     case 'lbs':
       return value * 0.453592

--- a/utils/health.ts
+++ b/utils/health.ts
@@ -11,24 +11,6 @@ export interface CalorieResult {
   description: string
 }
 
-export interface WaterIntakeResult {
-  baseWater: number
-  totalWater: number
-  totalWaterOz: number
-  activityAdjustment: number
-  climateAdjustment: number
-  exerciseAdjustment: number
-  specialConditionAdjustment: number
-  description: string
-  breakdown: {
-    base: string
-    activity: string
-    climate: string
-    exercise: string
-    specialCondition: string
-  }
-}
-
 export type Gender = 'male' | 'female'
 export type ActivityLevel =
   | 'sedentary'
@@ -36,8 +18,6 @@ export type ActivityLevel =
   | 'moderate'
   | 'active'
   | 'extra'
-export type Climate = 'temperate' | 'hot' | 'cold'
-export type SpecialCondition = 'none' | 'pregnancy' | 'breastfeeding'
 
 export const calculateBMI = (weight: number, height: number): BMIResult => {
   if (weight <= 0 || height <= 0) {

--- a/utils/math.ts
+++ b/utils/math.ts
@@ -234,61 +234,6 @@ export const calculateExpenseSplit = (
   }
 }
 
-/**
- * 住宅ローン計算
- */
-export const calculateMortgage = (
-  loanAmount: number,
-  annualRate: number,
-  termYears: number
-): {
-  monthlyPayment: number
-  totalPayment: number
-  totalInterest: number
-  monthlyBreakdown: Array<{
-    month: number
-    payment: number
-    principal: number
-    interest: number
-    balance: number
-  }>
-} => {
-  const monthlyRate = annualRate / 100 / 12
-  const numberOfPayments = termYears * 12
-
-  // 月額返済額計算
-  const monthlyPayment =
-    (loanAmount * (monthlyRate * Math.pow(1 + monthlyRate, numberOfPayments))) /
-    (Math.pow(1 + monthlyRate, numberOfPayments) - 1)
-
-  const totalPayment = monthlyPayment * numberOfPayments
-  const totalInterest = totalPayment - loanAmount
-
-  // 月別内訳計算
-  const monthlyBreakdown = []
-  let remainingBalance = loanAmount
-
-  for (let month = 1; month <= numberOfPayments; month++) {
-    const interestPayment = remainingBalance * monthlyRate
-    const principalPayment = monthlyPayment - interestPayment
-    remainingBalance -= principalPayment
-
-    monthlyBreakdown.push({
-      month,
-      payment: monthlyPayment,
-      principal: principalPayment,
-      interest: interestPayment,
-      balance: Math.max(0, remainingBalance),
-    })
-  }
-
-  return {
-    monthlyPayment,
-    totalPayment,
-    totalInterest,
-    monthlyBreakdown,
-  }
-}
 
 /**
  * 基礎代謝計算（Harris-Benedict式）

--- a/utils/password.ts
+++ b/utils/password.ts
@@ -219,34 +219,6 @@ export const estimateCrackTime = (
   }
 }
 
-/**
- * UUID v4を生成する
- */
-export const generateUUID = (): string => {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
-    const r = (Math.random() * 16) | 0
-    const v = c === 'x' ? r : (r & 0x3) | 0x8
-    return v.toString(16)
-  })
-}
-
-/**
- * ランダムな16進数文字列を生成する
- */
-export const generateRandomHex = (length: number): string => {
-  if (length < 1) {
-    throw new Error('長さは1以上である必要があります')
-  }
-
-  const hexChars = '0123456789abcdef'
-  let result = ''
-
-  for (let i = 0; i < length; i++) {
-    result += hexChars[Math.floor(Math.random() * hexChars.length)]
-  }
-
-  return result
-}
 
 /**
  * Luhnアルゴリズムでクレジットカード番号を検証する

--- a/utils/pomodoroTimer.ts
+++ b/utils/pomodoroTimer.ts
@@ -247,11 +247,6 @@ export function getPhaseDisplayName(phase: PomodoroPhase): string {
   }
 }
 
-export function formatTime(seconds: number): string {
-  const minutes = Math.floor(seconds / 60)
-  const remainingSeconds = seconds % 60
-  return `${minutes.toString().padStart(2, '0')}:${remainingSeconds.toString().padStart(2, '0')}`
-}
 
 export function formatDuration(minutes: number): string {
   if (minutes < 60) {

--- a/utils/water-intake.ts
+++ b/utils/water-intake.ts
@@ -1,12 +1,12 @@
 export type WeightUnit = 'kg' | 'lbs'
-export type ActivityLevel = 'sedentary' | 'moderate' | 'active'
+export type WaterActivityLevel = 'sedentary' | 'moderate' | 'active'
 export type Climate = 'temperate' | 'hot' | 'cold'
 export type SpecialCondition = 'none' | 'pregnancy' | 'breastfeeding'
 
 export interface WaterIntakeInput {
   weight: number
   weightUnit: WeightUnit
-  activityLevel: ActivityLevel
+  activityLevel: WaterActivityLevel
   climate: Climate
   specialCondition: SpecialCondition
   exerciseMinutes: number
@@ -28,7 +28,7 @@ export interface WaterIntakeResult {
 const BASE_WATER_PER_KG = 35
 
 // Activity level adjustments (percentage)
-const activityAdjustments: Record<ActivityLevel, number> = {
+const activityAdjustments: Record<WaterActivityLevel, number> = {
   sedentary: 0,
   moderate: 0.15, // +15%
   active: 0.3, // +30%
@@ -118,8 +118,8 @@ export function formatOunces(oz: number): string {
   return `${oz} oz`
 }
 
-export function getActivityLevelDescription(level: ActivityLevel): string {
-  const descriptions: Record<ActivityLevel, string> = {
+export function getActivityLevelDescription(level: WaterActivityLevel): string {
+  const descriptions: Record<WaterActivityLevel, string> = {
     sedentary: '座り仕事中心・軽い活動',
     moderate: '適度な活動・軽い運動',
     active: 'アクティブな生活・定期的な運動',


### PR DESCRIPTION
## 概要
Issue #56 で報告された duplicate imports 警告をすべて修正し、CI に検出処理を追加しました。

## 修正内容
### 重複した関数・型の整理
- **math.ts**: `calculateMortgage` を削除（mortgage-calculator.ts に統合済み）
- **password.ts**: `generateUUID` と `generateRandomHex` を削除（専用ファイルに移動済み）
- **pomodoroTimer.ts**: `formatTime` を削除（stopwatch.ts を使用）
- **health.ts**: 水分摂取関連の型を削除（water-intake.ts に統合）

### 型定義の重複解決
- `WeightUnit` と `ActivityLevel` の重複を解決
- 適切な名前空間に分離（`CalorieWeightUnit`, `WaterActivityLevel`）

### テスト修正
- `password.test.ts` のインポートを正しいファイルから行うよう修正
- 大文字小文字の正規表現を修正

### CI 強化
- duplicate imports を検出する新しいステップを追加
- `pnpm generate` で警告が出た場合はビルドを失敗させる

## テスト結果
- すべての単体テストが正常に通過
- `pnpm generate` で duplicate imports 警告が出ないことを確認

## チェックリスト
- [x] ローカルでlint/testが通ることを確認
- [x] `pnpm generate` で警告が出ないことを確認
- [x] CI に duplicate imports 検出機能を追加
- [x] 既存機能に影響がないことを確認

Closes #56

🤖 Generated with [Claude Code](https://claude.ai/code)