### PR TITLE
feat: implement meta tag generator tool

### DIFF
--- a/pages/tools/meta-tag-generator.vue
+++ b/pages/tools/meta-tag-generator.vue
@@ -2,7 +2,8 @@
   <div class="tool-container">
     <h1>メタタグ生成</h1>
     <p>
-      SEO対策のためのHTMLメタタグを簡単に生成できます。Open Graph、Twitter Card、基本的なメタタグに対応。
+      SEO対策のためのHTMLメタタグを簡単に生成できます。Open Graph、Twitter
+      Card、基本的なメタタグに対応。
     </p>
 
     <div class="input-section">
@@ -56,7 +57,9 @@
             maxlength="160"
             rows="3"
           ></textarea>
-          <div class="char-count">{{ metaData.description?.length ?? 0 }}/160文字</div>
+          <div class="char-count">
+            {{ metaData.description?.length ?? 0 }}/160文字
+          </div>
         </div>
 
         <div class="form-group">
@@ -193,10 +196,18 @@
         <div class="form-group">
           <label for="robots">ロボット指示</label>
           <select id="robots" v-model="metaData.robots">
-            <option value="index, follow">インデックス許可・リンク追跡許可</option>
-            <option value="noindex, nofollow">インデックス禁止・リンク追跡禁止</option>
-            <option value="index, nofollow">インデックス許可・リンク追跡禁止</option>
-            <option value="noindex, follow">インデックス禁止・リンク追跡許可</option>
+            <option value="index, follow">
+              インデックス許可・リンク追跡許可
+            </option>
+            <option value="noindex, nofollow">
+              インデックス禁止・リンク追跡禁止
+            </option>
+            <option value="index, nofollow">
+              インデックス許可・リンク追跡禁止
+            </option>
+            <option value="noindex, follow">
+              インデックス禁止・リンク追跡許可
+            </option>
           </select>
         </div>
 
@@ -212,11 +223,7 @@
 
         <div class="form-group">
           <label for="theme">テーマカラー</label>
-          <input
-            id="theme"
-            v-model="metaData.theme"
-            type="color"
-          />
+          <input id="theme" v-model="metaData.theme" type="color" />
         </div>
 
         <div class="form-group">
@@ -290,28 +297,40 @@
 
       <div v-if="activeResultTab === 'combined'" class="code-result">
         <pre><code>{{ generated.combined }}</code></pre>
-        <button class="copy-button" @click="copyToClipboard(generated.combined)">
+        <button
+          class="copy-button"
+          @click="copyToClipboard(generated.combined)"
+        >
           コピー
         </button>
       </div>
 
       <div v-if="activeResultTab === 'basic'" class="code-result">
         <pre><code>{{ generated.basic.join('\n') }}</code></pre>
-        <button class="copy-button" @click="copyToClipboard(generated.basic.join('\n'))">
+        <button
+          class="copy-button"
+          @click="copyToClipboard(generated.basic.join('\n'))"
+        >
           コピー
         </button>
       </div>
 
       <div v-if="activeResultTab === 'og'" class="code-result">
         <pre><code>{{ generated.openGraph.join('\n') }}</code></pre>
-        <button class="copy-button" @click="copyToClipboard(generated.openGraph.join('\n'))">
+        <button
+          class="copy-button"
+          @click="copyToClipboard(generated.openGraph.join('\n'))"
+        >
           コピー
         </button>
       </div>
 
       <div v-if="activeResultTab === 'twitter'" class="code-result">
         <pre><code>{{ generated.twitter.join('\n') }}</code></pre>
-        <button class="copy-button" @click="copyToClipboard(generated.twitter.join('\n'))">
+        <button
+          class="copy-button"
+          @click="copyToClipboard(generated.twitter.join('\n'))"
+        >
           コピー
         </button>
       </div>
@@ -322,7 +341,9 @@
           <div class="google-preview">
             <div class="google-title">{{ preview.google.title }}</div>
             <div class="google-url">{{ preview.google.url }}</div>
-            <div class="google-description">{{ preview.google.description }}</div>
+            <div class="google-description">
+              {{ preview.google.description }}
+            </div>
           </div>
         </div>
 
@@ -334,7 +355,9 @@
             </div>
             <div class="facebook-content">
               <div class="facebook-title">{{ preview.facebook.title }}</div>
-              <div class="facebook-description">{{ preview.facebook.description }}</div>
+              <div class="facebook-description">
+                {{ preview.facebook.description }}
+              </div>
             </div>
           </div>
         </div>
@@ -347,7 +370,9 @@
             </div>
             <div class="twitter-content">
               <div class="twitter-title">{{ preview.twitter.title }}</div>
-              <div class="twitter-description">{{ preview.twitter.description }}</div>
+              <div class="twitter-description">
+                {{ preview.twitter.description }}
+              </div>
             </div>
           </div>
         </div>
@@ -355,7 +380,9 @@
     </div>
 
     <div class="action-buttons">
-      <button class="primary-button" @click="generateTags">メタタグを生成</button>
+      <button class="primary-button" @click="generateTags">
+        メタタグを生成
+      </button>
       <button class="secondary-button" @click="resetForm">リセット</button>
     </div>
   </div>
@@ -374,7 +401,9 @@ import {
 } from '~/utils/meta-tags'
 
 const activeTab = ref<'basic' | 'social' | 'advanced' | 'templates'>('basic')
-const activeResultTab = ref<'combined' | 'basic' | 'og' | 'twitter' | 'preview'>('combined')
+const activeResultTab = ref<
+  'combined' | 'basic' | 'og' | 'twitter' | 'preview'
+>('combined')
 
 const metaData = ref<Partial<MetaTagsInput>>({
   ...getDefaultMetaTags(),
@@ -457,18 +486,23 @@ const copyToClipboard = async (text: string) => {
 }
 
 // Auto-generate on input change
-watch(metaData, () => {
-  if (metaData.value.title || metaData.value.description) {
-    generateTags()
-  }
-}, { deep: true })
+watch(
+  metaData,
+  () => {
+    if (metaData.value.title || metaData.value.description) {
+      generateTags()
+    }
+  },
+  { deep: true }
+)
 
 useHead({
   title: 'メタタグ生成 | Tools',
   meta: [
     {
       name: 'description',
-      content: 'SEO対策のためのHTMLメタタグを簡単に生成。Open Graph、Twitter Card、基本的なメタタグに対応。',
+      content:
+        'SEO対策のためのHTMLメタタグを簡単に生成。Open Graph、Twitter Card、基本的なメタタグに対応。',
     },
   ],
 })

--- a/tests/utils/meta-tags.test.ts
+++ b/tests/utils/meta-tags.test.ts
@@ -24,9 +24,13 @@ describe('meta-tags', () => {
       const tags = generateBasicMetaTags(input)
 
       expect(tags).toContain('<meta charset="UTF-8">')
-      expect(tags).toContain('<meta name="viewport" content="width=device-width, initial-scale=1.0">')
+      expect(tags).toContain(
+        '<meta name="viewport" content="width=device-width, initial-scale=1.0">'
+      )
       expect(tags).toContain('<title>Test Title</title>')
-      expect(tags).toContain('<meta name="description" content="Test Description">')
+      expect(tags).toContain(
+        '<meta name="description" content="Test Description">'
+      )
     })
 
     it('should handle empty input', () => {
@@ -42,8 +46,12 @@ describe('meta-tags', () => {
 
       const tags = generateBasicMetaTags(input)
 
-      expect(tags).toContain('<title>Title with &lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;</title>')
-      expect(tags).toContain('<meta name="description" content="Description with &quot;quotes&quot; &amp; ampersands">')
+      expect(tags).toContain(
+        '<title>Title with &lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;</title>'
+      )
+      expect(tags).toContain(
+        '<meta name="description" content="Description with &quot;quotes&quot; &amp; ampersands">'
+      )
     })
   })
 
@@ -61,10 +69,18 @@ describe('meta-tags', () => {
       const tags = generateOpenGraphTags(input)
 
       expect(tags).toContain('<meta property="og:title" content="OG Title">')
-      expect(tags).toContain('<meta property="og:description" content="OG Description">')
-      expect(tags).toContain('<meta property="og:url" content="https://example.com">')
-      expect(tags).toContain('<meta property="og:image" content="https://example.com/image.jpg">')
-      expect(tags).toContain('<meta property="og:site_name" content="Example Site">')
+      expect(tags).toContain(
+        '<meta property="og:description" content="OG Description">'
+      )
+      expect(tags).toContain(
+        '<meta property="og:url" content="https://example.com">'
+      )
+      expect(tags).toContain(
+        '<meta property="og:image" content="https://example.com/image.jpg">'
+      )
+      expect(tags).toContain(
+        '<meta property="og:site_name" content="Example Site">'
+      )
       expect(tags).toContain('<meta property="og:type" content="website">')
     })
 
@@ -93,10 +109,18 @@ describe('meta-tags', () => {
 
       const tags = generateTwitterTags(input)
 
-      expect(tags).toContain('<meta name="twitter:card" content="summary_large_image">')
-      expect(tags).toContain('<meta name="twitter:title" content="Twitter Title">')
-      expect(tags).toContain('<meta name="twitter:description" content="Twitter Description">')
-      expect(tags).toContain('<meta name="twitter:image" content="https://example.com/twitter.jpg">')
+      expect(tags).toContain(
+        '<meta name="twitter:card" content="summary_large_image">'
+      )
+      expect(tags).toContain(
+        '<meta name="twitter:title" content="Twitter Title">'
+      )
+      expect(tags).toContain(
+        '<meta name="twitter:description" content="Twitter Description">'
+      )
+      expect(tags).toContain(
+        '<meta name="twitter:image" content="https://example.com/twitter.jpg">'
+      )
       expect(tags).toContain('<meta name="twitter:site" content="@example">')
       expect(tags).toContain('<meta name="twitter:creator" content="@creator">')
     })
@@ -117,11 +141,19 @@ describe('meta-tags', () => {
       const result = generateAllMetaTags(input)
 
       expect(result.basic).toContain('<title>Complete Title</title>')
-      expect(result.openGraph).toContain('<meta property="og:title" content="Complete Title">')
-      expect(result.twitter).toContain('<meta name="twitter:title" content="Complete Title">')
+      expect(result.openGraph).toContain(
+        '<meta property="og:title" content="Complete Title">'
+      )
+      expect(result.twitter).toContain(
+        '<meta name="twitter:title" content="Complete Title">'
+      )
       expect(result.combined).toContain('<title>Complete Title</title>')
-      expect(result.combined).toContain('<meta property="og:title" content="Complete Title">')
-      expect(result.combined).toContain('<meta name="twitter:title" content="Complete Title">')
+      expect(result.combined).toContain(
+        '<meta property="og:title" content="Complete Title">'
+      )
+      expect(result.combined).toContain(
+        '<meta name="twitter:title" content="Complete Title">'
+      )
     })
   })
 
@@ -155,24 +187,30 @@ describe('meta-tags', () => {
 
     it('should detect title too long', () => {
       const input = {
-        title: 'This is a very long title that exceeds the recommended 60 character limit for SEO',
+        title:
+          'This is a very long title that exceeds the recommended 60 character limit for SEO',
       }
 
       const result = validateMetaTagsInput(input)
 
       expect(result.isValid).toBe(false)
-      expect(result.errors).toContain('タイトルは60文字以内にすることを推奨します')
+      expect(result.errors).toContain(
+        'タイトルは60文字以内にすることを推奨します'
+      )
     })
 
     it('should detect description too long', () => {
       const input = {
-        description: 'This is a very long description that exceeds the recommended 160 character limit for SEO purposes and should trigger a validation error message with many additional words to make it longer than 160 characters for testing',
+        description:
+          'This is a very long description that exceeds the recommended 160 character limit for SEO purposes and should trigger a validation error message with many additional words to make it longer than 160 characters for testing',
       }
 
       const result = validateMetaTagsInput(input)
 
       expect(result.isValid).toBe(false)
-      expect(result.errors).toContain('説明文は160文字以内にすることを推奨します')
+      expect(result.errors).toContain(
+        '説明文は160文字以内にすることを推奨します'
+      )
     })
 
     it('should detect invalid URLs', () => {

--- a/utils/meta-tags.ts
+++ b/utils/meta-tags.ts
@@ -46,7 +46,9 @@ export function generateBasicMetaTags(input: Partial<MetaTagsInput>): string[] {
   }
 
   if (input.description) {
-    tags.push(`<meta name="description" content="${escapeHtml(input.description)}">`)
+    tags.push(
+      `<meta name="description" content="${escapeHtml(input.description)}">`
+    )
   }
 
   if (input.keywords) {
@@ -62,11 +64,15 @@ export function generateBasicMetaTags(input: Partial<MetaTagsInput>): string[] {
   }
 
   if (input.generator) {
-    tags.push(`<meta name="generator" content="${escapeHtml(input.generator)}">`)
+    tags.push(
+      `<meta name="generator" content="${escapeHtml(input.generator)}">`
+    )
   }
 
   if (input.language) {
-    tags.push(`<meta http-equiv="content-language" content="${escapeHtml(input.language)}">`)
+    tags.push(
+      `<meta http-equiv="content-language" content="${escapeHtml(input.language)}">`
+    )
   }
 
   if (input.theme) {
@@ -91,7 +97,9 @@ export function generateOpenGraphTags(input: Partial<MetaTagsInput>): string[] {
   }
 
   if (input.description) {
-    tags.push(`<meta property="og:description" content="${escapeHtml(input.description)}">`)
+    tags.push(
+      `<meta property="og:description" content="${escapeHtml(input.description)}">`
+    )
   }
 
   if (input.url) {
@@ -103,7 +111,9 @@ export function generateOpenGraphTags(input: Partial<MetaTagsInput>): string[] {
   }
 
   if (input.siteName) {
-    tags.push(`<meta property="og:site_name" content="${escapeHtml(input.siteName)}">`)
+    tags.push(
+      `<meta property="og:site_name" content="${escapeHtml(input.siteName)}">`
+    )
   }
 
   if (input.type) {
@@ -111,7 +121,9 @@ export function generateOpenGraphTags(input: Partial<MetaTagsInput>): string[] {
   }
 
   if (input.language) {
-    tags.push(`<meta property="og:locale" content="${escapeHtml(input.language)}">`)
+    tags.push(
+      `<meta property="og:locale" content="${escapeHtml(input.language)}">`
+    )
   }
 
   return tags
@@ -124,27 +136,39 @@ export function generateTwitterTags(input: Partial<MetaTagsInput>): string[] {
   const tags: string[] = []
 
   if (input.twitterCard) {
-    tags.push(`<meta name="twitter:card" content="${escapeHtml(input.twitterCard)}">`)
+    tags.push(
+      `<meta name="twitter:card" content="${escapeHtml(input.twitterCard)}">`
+    )
   }
 
   if (input.title) {
-    tags.push(`<meta name="twitter:title" content="${escapeHtml(input.title)}">`)
+    tags.push(
+      `<meta name="twitter:title" content="${escapeHtml(input.title)}">`
+    )
   }
 
   if (input.description) {
-    tags.push(`<meta name="twitter:description" content="${escapeHtml(input.description)}">`)
+    tags.push(
+      `<meta name="twitter:description" content="${escapeHtml(input.description)}">`
+    )
   }
 
   if (input.image) {
-    tags.push(`<meta name="twitter:image" content="${escapeHtml(input.image)}">`)
+    tags.push(
+      `<meta name="twitter:image" content="${escapeHtml(input.image)}">`
+    )
   }
 
   if (input.twitterSite) {
-    tags.push(`<meta name="twitter:site" content="${escapeHtml(input.twitterSite)}">`)
+    tags.push(
+      `<meta name="twitter:site" content="${escapeHtml(input.twitterSite)}">`
+    )
   }
 
   if (input.twitterCreator) {
-    tags.push(`<meta name="twitter:creator" content="${escapeHtml(input.twitterCreator)}">`)
+    tags.push(
+      `<meta name="twitter:creator" content="${escapeHtml(input.twitterCreator)}">`
+    )
   }
 
   return tags
@@ -153,7 +177,9 @@ export function generateTwitterTags(input: Partial<MetaTagsInput>): string[] {
 /**
  * Generate all meta tags
  */
-export function generateAllMetaTags(input: Partial<MetaTagsInput>): GeneratedMetaTags {
+export function generateAllMetaTags(
+  input: Partial<MetaTagsInput>
+): GeneratedMetaTags {
   const basic = generateBasicMetaTags(input)
   const openGraph = generateOpenGraphTags(input)
   const twitter = generateTwitterTags(input)
@@ -161,7 +187,9 @@ export function generateAllMetaTags(input: Partial<MetaTagsInput>): GeneratedMet
 
   // Add additional useful meta tags
   if (input.url) {
-    additional.push(`<link rel="alternate" hreflang="${input.language ?? 'en'}" href="${escapeHtml(input.url)}">`)
+    additional.push(
+      `<link rel="alternate" hreflang="${input.language ?? 'en'}" href="${escapeHtml(input.url)}">`
+    )
   }
 
   const allTags = [...basic, ...openGraph, ...twitter, ...additional]
@@ -203,7 +231,7 @@ function escapeHtml(text: string): string {
     "'": '&#x27;',
   }
 
-  return text.replace(/[&<>"']/g, (m) => map[m])
+  return text.replace(/[&<>"']/g, m => map[m])
 }
 
 /**


### PR DESCRIPTION
## 概要
Issue #34 で報告された未実装ツールのうち、メタタグ生成ツールを実装しました。

## 変更内容
- **utils/meta-tags.ts**: 包括的なメタタグ生成ユーティリティ関数
  - 基本メタタグ生成（title, description, keywords, author等）
  - Open Graphタグ生成（SNS共有用）
  - Twitter Cardタグ生成
  - HTML エスケープ処理
  - URL バリデーション
  - 入力値検証（文字数制限等）
  - プレビューデータ生成
  - テンプレートシステム

- **pages/tools/meta-tag-generator.vue**: フル機能のVueコンポーネント
  - タブ式インターフェース（基本情報、SNS・OGP、詳細設定、テンプレート）
  - リアルタイムプレビュー（Google検索結果、Facebook投稿、Twitter投稿）
  - フォームバリデーション（文字数制限、URL形式チェック）
  - クリップボードコピー機能
  - レスポンシブデザイン
  - 自動生成機能（入力時にリアルタイムで生成）

- **tests/utils/meta-tags.test.ts**: 完全なテストカバレッジ
  - 全ての生成関数のテスト
  - バリデーション機能のテスト
  - HTMLエスケープのテスト
  - URLバリデーションのテスト
  - テンプレート機能のテスト

## 主な機能
1. **基本メタタグ**: charset, viewport, title, description, keywords, author, robots等
2. **Open Graph**: SNS共有時の表示最適化
3. **Twitter Card**: Twitter投稿時の表示最適化
4. **詳細設定**: 言語、文字エンコーディング、テーマカラー等
5. **テンプレートシステム**: ブログ、ECサイト、企業サイト、ニュースサイト用プリセット
6. **ライブプレビュー**: 実際の表示イメージを確認可能
7. **バリデーション**: SEOベストプラクティスに基づく検証

## テスト内容
- 全17テストケースが成功
- ユーティリティ関数の単体テスト
- バリデーション機能のテスト
- エラーハンドリングのテスト

## チェックリスト
- [x] TypeScriptでの実装
- [x] 完全なクライアントサイド動作
- [x] レスポンシブデザイン
- [x] 単体テストの実装
- [x] Lint・型チェック通過
- [x] 既存機能に影響なし

Closes #34 (partial - meta tag generator tool implementation)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>