### PR TITLE
chore: add .serena/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ Thumbs.db
 # Package manager lockfiles (keep pnpm-lock.yaml only)
 package-lock.json
 yarn.lock
+
+# Serena (MCP server) files
+.serena/


### PR DESCRIPTION
## 概要
.serena/ ディレクトリを .gitignore に追加

## 変更内容
- MCPサーバー（serena）のファイルをバージョン管理から除外
- .serena/ ディレクトリには一時的なプロジェクト設定やメモリファイルが含まれる
- 個人の開発環境固有のファイルのため、リポジトリには含めない

## テスト内容
- 既存のlint/test/typecheckが全て通ることを確認
- 品質チェックに問題なし

## チェックリスト
- [x] ローカルでlint/testが通ることを確認
- [x] 既存機能に影響がないことを確認
- [x] .gitignoreの適切な位置に追加

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>